### PR TITLE
Use python:3.7-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3-alpine3.12
+FROM python:3.7-slim
 
 # Grab Flask, the most extremely awesome Python module ever!
-RUN pip3 install Flask
+RUN pip install  --trusted-host=pypi.python.org --trusted-host=pypi.org --trusted-host=files.pythonhosted.org Flask
 
 # Dev tools (can be removed for production)
 # RUN apt update && apt install -y vim curl jq


### PR DESCRIPTION
Alpine base images are not safe to use because the host Linux system needs to have a particular level of libseccomp.
Target edge devices will fail to run this container reliability.  Switch to a different python base image.  I will trade image size for reliability in this teaching example. 
Works better on Raspberry Pi OS.